### PR TITLE
Update dotnet SignalR to version 8, and modify for Unity - IL2CPP

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -67,7 +67,7 @@ public partial class HubConnection : IAsyncDisposable
     };
 
     private static readonly MethodInfo _sendStreamItemsMethod = typeof(HubConnection).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Single(m => m.Name.Equals(nameof(SendStreamItems)));
-    private static readonly MethodInfo _sendIAsyncStreamItemsMethod = typeof(HubConnection).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Single(m => m.Name.Equals(nameof(SendIAsyncEnumerableStreamItems)));
+    private static readonly MethodInfo _sendIAsyncStreamItemsMethod = typeof(HubConnection).GetMethods(BindingFlags.Public | BindingFlags.Instance).Single(m => m.Name.Equals(nameof(SendIAsyncEnumerableStreamItems)));
 
     // Persistent across all connections
     private readonly ILoggerFactory _loggerFactory;
@@ -857,7 +857,9 @@ public partial class HubConnection : IAsyncDisposable
     }
 
     // this is called via reflection using the `_sendIAsyncStreamItemsMethod` field
-    private Task SendIAsyncEnumerableStreamItems<T>(ConnectionState connectionState, string streamId, IAsyncEnumerable<T> stream, CancellationTokenSource tokenSource)
+#pragma warning disable RS0016 // Add public types and members to the declared API
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    public Task SendIAsyncEnumerableStreamItems<T>(ConnectionState connectionState, string streamId, IAsyncEnumerable<T> stream, CancellationTokenSource tokenSource)
     {
         async Task ReadAsyncEnumerableStream()
         {
@@ -1896,7 +1898,9 @@ public partial class HubConnection : IAsyncDisposable
         }
     }
 
-    private sealed class ConnectionState : IInvocationBinder
+#pragma warning disable RS0016 // Add public types and members to the declared API
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    public  sealed class ConnectionState : IInvocationBinder
     {
         private readonly HubConnection _hubConnection;
         private readonly ILogger _logger;

--- a/src/SignalR/clients/csharp/Client.Core/src/Internal/InvocationRequest.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/Internal/InvocationRequest.cs
@@ -10,7 +10,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.SignalR.Client.Internal;
 
-internal abstract partial class InvocationRequest : IDisposable
+#pragma warning disable RS0016 // Add public types and members to the declared API
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+public abstract partial class InvocationRequest : IDisposable
 {
     private readonly CancellationTokenRegistration _cancellationTokenRegistration;
 

--- a/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Shipped.txt
+++ b/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Shipped.txt
@@ -45,6 +45,7 @@ Microsoft.AspNetCore.SignalR.Client.RetryContext.PreviousRetryCount.set -> void
 Microsoft.AspNetCore.SignalR.Client.RetryContext.RetryContext() -> void
 Microsoft.AspNetCore.SignalR.Client.RetryContext.RetryReason.get -> System.Exception?
 Microsoft.AspNetCore.SignalR.Client.RetryContext.RetryReason.set -> void
+Microsoft.AspNetCore.SignalR.Client.Internal.InvocationRequest
 override Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder.Equals(object? obj) -> bool
 override Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder.GetHashCode() -> int
 override Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder.ToString() -> string?

--- a/src/SignalR/common/Shared/TimerAwaitable.cs
+++ b/src/SignalR/common/Shared/TimerAwaitable.cs
@@ -10,7 +10,9 @@ using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Internal;
 
-internal sealed class TimerAwaitable : IDisposable, ICriticalNotifyCompletion
+#pragma warning disable RS0016 // Add public types and members to the declared API
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+public sealed class TimerAwaitable : IDisposable, ICriticalNotifyCompletion
 {
     private Timer? _timer;
     private Action? _callback;


### PR DESCRIPTION
Changes made to SignalR source to be able to be built by Unity - IL2CPP

Checkout the required verison tag,
Create a branch from there
Rebase this commit `https://github.com/SolidClouds/aspnetcore/pull/1/commits/170bcaa91427e510ba0ef33708c1479b5979af5c` to that branch.
